### PR TITLE
feat(shell): add zsh with starship, bat, and plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,18 @@ When adding new config, put it in base unless it's obviously personal. When in d
    ```
 3. Test with `make check`, then `make switch`
 
+## Git workflow
+
+- **Direct to main**: config tweaks, bug fixes, small additions within an existing module
+- **Branch + PR**: new modules/phases, structural changes to flake.nix, anything touching multiple modules
+- PRs get automatic Copilot review via the "Protect main" ruleset
+- Repo owner can bypass force-push protection when needed (e.g., amending commits)
+
 ## Style preferences
 
 - **Conventional commits.** All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/): `type(scope): description`. Common types: `feat`, `fix`, `docs`, `chore`, `refactor`. Scope is optional (e.g., `feat(shell): add fzf integration`).
 - **No ambiguous abbreviations.** Use explicit names: `makeDarwin` not `mkDarwin`, `homeModules` not `hm`. The Nix community loves `mk`-prefixed names (from `mkDerivation`) but we prefer clarity. Exception: don't rename things from upstream APIs (`lib.mkIf` stays as `lib.mkIf`).
+- **Discuss every design choice with Thomas.** Don't make assumptions about preferences. Present options with trade-offs.
 
 ## Module conventions
 

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,6 +1,10 @@
 { pkgs, ... }:
 
 {
+  imports = [
+    ./shell
+  ];
+
   # Let home-manager manage itself (provides the `home-manager` CLI).
   programs.home-manager.enable = true;
 

--- a/home/shell/default.nix
+++ b/home/shell/default.nix
@@ -1,0 +1,91 @@
+{ pkgs, ... }:
+
+{
+  programs.zsh = {
+    enable = true;
+    autosuggestion.enable = true;
+    syntaxHighlighting.enable = true;
+
+    history = {
+      size = 50000;
+      save = 50000;
+      ignoreDups = true;
+      ignoreAllDups = true;
+      ignoreSpace = true;
+      extended = true;
+      share = true;
+    };
+  };
+
+  # Starship prompt
+  programs.starship = {
+    enable = true;
+    enableZshIntegration = true;
+    settings = {
+      format = "$directory$git_branch$git_status$nix_shell$python$nodejs$rust$fill$cmd_duration$time$line_break$character";
+
+      git_status = {
+        format = "([$all_status$ahead_behind]($style) )";
+        ahead = "↑$count";
+        behind = "↓$count";
+        diverged = "↑$ahead_count↓$behind_count";
+        staged = "+$count";
+        modified = "!$count";
+        untracked = "?$count";
+        deleted = "✘$count";
+        renamed = "»$count";
+        stashed = "\\$$count";
+        conflicted = "=$count";
+      };
+
+      fill.symbol = "·";
+
+      character = {
+        success_symbol = "[❯](bold green)";
+        error_symbol = "[❯](bold red)";
+      };
+
+      directory = {
+        truncation_length = 3;
+        truncation_symbol = "…/";
+      };
+
+      cmd_duration = {
+        min_time = 2000;
+        format = "[$duration]($style) ";
+      };
+
+      time = {
+        disabled = false;
+        format = "[$time]($style)";
+        time_format = "%H:%M:%S";
+      };
+
+      nix_shell = {
+        format = "via [$symbol$state]($style) ";
+        symbol = "❄️ ";
+      };
+
+      python.format = "via [$symbol$version]($style) ";
+      nodejs.format = "via [$symbol$version]($style) ";
+      rust.format = "via [$symbol$version]($style) ";
+    };
+  };
+
+  # bat: syntax-highlighted cat replacement + man pager
+  programs.bat = {
+    enable = true;
+    config = {
+      theme = "ansi";
+      style = "numbers,changes";
+    };
+  };
+
+  programs.zsh.shellAliases.cat = "bat";
+
+  home.sessionVariables = {
+    MANPAGER = "sh -c 'col -bx | bat -l man -p'";
+  };
+
+  home.sessionPath = [ "$HOME/.local/bin" ];
+}

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -7,8 +7,11 @@
   # Configure Nix settings via Determinate instead.
   nix.enable = false;
 
-  # No system-level packages yet — everything goes through home-manager.
+  # System-level packages (available to all users).
   environment.systemPackages = [ ];
+
+  # System fonts (available to all apps).
+  fonts.packages = [ pkgs.nerd-fonts.fira-code ];
 
   # Platform identifier for this host.
   nixpkgs.hostPlatform = "aarch64-darwin";


### PR DESCRIPTION
## Summary

- Zsh with autosuggestions, syntax highlighting, and sensible history defaults
- Starship prompt: 2-line, dotted fill, git status with counts (↑↓+!?), command duration, nix shell indicator, contextual language versions
- `bat` as `cat` replacement and colored man pager
- FiraCode Nerd Font installed via nix-darwin
- `~/.local/bin` added to PATH
- Git workflow conventions documented in CLAUDE.md

## Test plan

- [x] `nix flake check` passes
- [x] `make switch` applies successfully
- [x] Starship prompt renders correctly in new terminal
- [x] Autosuggestions and syntax highlighting work
- [x] Git status shows counts and change types
- [x] `bat` provides colored output

🤖 Generated with [Claude Code](https://claude.com/claude-code)