### PR TITLE
feat(git): add git, delta, and gh configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,23 @@ When adding new config, put it in base unless it's obviously personal. When in d
 
 - **Direct to main**: config tweaks, bug fixes, small additions within an existing module
 - **Branch + PR**: new modules/phases, structural changes to flake.nix, anything touching multiple modules
-- PRs get automatic Copilot review via the "Protect main" ruleset
-- Repo owner can bypass force-push protection when needed (e.g., amending commits)
+
+### PR workflow (branch + PR)
+
+1. Create a feature branch: `git checkout -b feat/<name>`
+2. Make changes, test with `make check` and `make switch`
+3. Commit with conventional commit messages
+4. Push and create a PR linking the relevant phase issue
+5. Copilot auto-reviews the PR via the "Protect main" ruleset — review its comments, reply/resolve as appropriate
+6. Once CI passes (after CI is set up) and comments are resolved, merge
+7. Pull main locally, delete the feature branch
+
+### Issue tracking
+
+- Each implementation phase has a corresponding GitHub issue
+- Keep issues up to date: when decisions are made, work starts, or a phase completes, update the relevant issue
+- Issues are the permanent record of decisions and progress
+- Repo owner can bypass force-push protection when needed (e.g., amending commits on a PR branch)
 
 ## Style preferences
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ nix-config/
 
 All inputs follow a single nixpkgs to avoid version drift. If an input ever breaks against nixpkgs-unstable (extremely rare), temporarily pin it to a specific rev — see CLAUDE.md for instructions.
 
+## Manual setup 🔧✋
+
+Some things can't be declared in Nix (yet). See [`docs/manual-setup.md`](docs/manual-setup.md) for post-deploy steps on new machines.
+
 ## License 📄
 
 MIT

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -1,0 +1,31 @@
+# Manual setup
+
+Some things can't be declared in Nix. This is the checklist for new machines after `make switch`.
+
+## macOS
+
+### iTerm2
+
+- **Font**: Preferences → Profiles → Text → Font → select "FiraCode Nerd Font"
+  - FiraCode Nerd Font is installed by nix-darwin, but iTerm2's font preference must be set manually (iTerm2 rewrites its plist, making Nix management fragile)
+
+### Determinate Nix
+
+- First bootstrap may require: `sudo mv /etc/zshenv /etc/zshenv.before-nix-darwin`
+  - Only needed if Determinate Nix owns `/etc/zshenv` before nix-darwin is installed
+
+## All platforms
+
+### GitHub CLI
+
+- Run `gh auth login` after first deploy to authenticate git operations
+
+## Cleanup
+
+### home-manager backup files
+
+When home-manager encounters existing files it needs to manage, it renames them with a `.hm-backup` extension. After verifying everything works, search for and remove these:
+
+```sh
+find ~ -name "*.hm-backup" -maxdepth 3
+```

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             users.users.${username}.home = "/Users/${username}";
             home-manager.useGlobalPkgs = true;
             home-manager.useUserPackages = true;
+            home-manager.backupFileExtension = "hm-backup";
             home-manager.users.${username} = {
               imports = homeModules;
               home.username = username;

--- a/home/default.nix
+++ b/home/default.nix
@@ -3,6 +3,7 @@
 {
   imports = [
     ./shell
+    ./git
   ];
 
   # Let home-manager manage itself (provides the `home-manager` CLI).

--- a/home/git/default.nix
+++ b/home/git/default.nix
@@ -1,0 +1,105 @@
+{ pkgs, ... }:
+
+{
+  programs.git = {
+    enable = true;
+
+    settings = {
+      user.name = "Thomas Skovlund Hansen";
+      user.email = "thomas@skovlund.dev";
+
+      core.editor = "nvim";
+
+      init.defaultBranch = "main";
+      pull.rebase = true;
+      push.autoSetupRemote = true;
+      rerere.enabled = true;
+
+      alias = {
+        flog = "log --graph --oneline --decorate";
+        st = "status";
+        co = "checkout";
+        sw = "switch";
+        br = "branch";
+        ci = "commit";
+        ca = "commit --amend";
+        di = "diff";
+        ds = "diff --staged";
+        unstage = "reset HEAD --";
+        last = "log -1 HEAD";
+      };
+    };
+
+    ignores = [
+      # macOS
+      ".DS_Store"
+      ".AppleDouble"
+      "._*"
+      ".Spotlight-V100"
+      ".Trashes"
+
+      # Windows
+      "Thumbs.db"
+
+      # Vim
+      "[._]*.s[a-v][a-z]"
+      "!*.svg"
+      "[._]*.sw[a-p]"
+      "[._]s[a-rt-v][a-z]"
+      "[._]ss[a-gi-z]"
+      "[._]sw[a-p]"
+      "Session.vim"
+      "Sessionx.vim"
+      ".netrwhist"
+      "*~"
+      "[._]*.un~"
+      "tags"
+
+      # VS Code
+      ".vscode/*"
+      "!.vscode/settings.json"
+      "!.vscode/tasks.json"
+      "!.vscode/launch.json"
+      "!.vscode/extensions.json"
+      "*.code-workspace"
+      ".history/"
+
+      # JetBrains
+      ".idea/"
+      "*.iml"
+
+      # Environment files
+      ".env"
+      ".env.local"
+
+      # Nix / direnv
+      ".direnv/"
+
+      # Python
+      "*.pyc"
+      "__pycache__/"
+
+      # AI tools
+      ".claude/"
+      ".copilot/"
+      ".cursor/"
+    ];
+  };
+
+  # delta: syntax-highlighted diffs
+  programs.delta = {
+    enable = true;
+    enableGitIntegration = true;
+    options = {
+      navigate = true;
+      line-numbers = true;
+      syntax-theme = "ansi";
+    };
+  };
+
+  # GitHub CLI (credential helper enabled by default)
+  programs.gh = {
+    enable = true;
+    settings.git_protocol = "https";
+  };
+}

--- a/home/shell/default.nix
+++ b/home/shell/default.nix
@@ -6,6 +6,16 @@
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
 
+    initExtra = ''
+      # iTerm2 shell integration (command framing, clickable marks, etc.)
+      if [ "$TERM_PROGRAM" = "iTerm.app" ]; then
+        if [ ! -e "$HOME/.iterm2_shell_integration.zsh" ]; then
+          curl -Ls https://iterm2.com/shell_integration/zsh -o "$HOME/.iterm2_shell_integration.zsh"
+        fi
+        source "$HOME/.iterm2_shell_integration.zsh"
+      fi
+    '';
+
     history = {
       size = 50000;
       save = 50000;


### PR DESCRIPTION
## Summary

- Declarative git config via home-manager: identity, nvim editor, `pull.rebase`, `push.autoSetupRemote`, `rerere.enabled`
- Curated alias set: `flog`, `st`, `co`, `sw`, `br`, `ci`, `ca`, `di`, `ds`, `unstage`, `last`
- Global gitignore covering macOS, Vim, VS Code, JetBrains, `.env`, direnv, Python, and AI tools (`.claude/`, `.copilot/`, `.cursor/`)
- delta as syntax-highlighted diff pager with line numbers
- gh CLI with HTTPS credential helper (switching to SSH planned for Phase 8)
- Full PR workflow and issue tracking process documented in CLAUDE.md
- `docs/manual-setup.md` for post-deploy manual steps, referenced from README

Closes #4

## Test plan

- [x] `make check` passes
- [x] `make switch` applies successfully
- [ ] `git config` reflects new settings (identity, aliases, editor, rebase)
- [ ] `git diff` shows delta-formatted output
- [ ] `gh auth status` works with credential helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)