### PR TITLE
ci: add GitHub Actions workflow for nix flake check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,26 @@
+name: Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    name: nix flake check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: DeterminateSystems/determinate-nix-action@89ab342bd48ff7318caf8d39d6a330c7b1df8f2f # v3
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+        with:
+          use-flakehub: false
+      - uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
+      - run: nix flake check


### PR DESCRIPTION
## Summary

- GitHub Actions workflow that runs `nix flake check` on every PR to main
- Runs on both Linux (`ubuntu-latest`) and macOS (`macos-latest`)
- Uses Determinate Systems action stack: `determinate-nix-action@v3`, `magic-nix-cache-action@v13`, `flake-checker-action@v12`
- FlakeHub disabled (not needed), explicit least-privilege permissions (`contents: read`)
- Dependabot configured to keep GitHub Actions versions up to date (weekly checks)
- Commit hooks deferred to after Phase 4 (direnv) — see #11

Closes #5

## Test plan

- [x] This PR itself should trigger the workflow — check the Actions tab
- [x] Both Linux and macOS jobs should pass
- [x] After merge, add as required status check in "Protect main" ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)