### PR TITLE
feat(tools): add CLI toolkit, direnv, and essentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,34 @@ nix-config/
 └── secrets/                     # agenix encrypted secrets
 ```
 
+## What's included 🧰
+
+### Shell
+- [zsh](https://www.zsh.org/) with [starship](https://starship.rs/) prompt, [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions), [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting)
+- [bat](https://github.com/sharkdp/bat) — syntax-highlighted cat replacement + man pager
+- [FiraCode Nerd Font](https://github.com/tonsky/FiraCode)
+
+### Git
+- [delta](https://github.com/dandavison/delta) — syntax-highlighted diffs
+- [gh](https://cli.github.com/) — GitHub CLI with credential helper
+
+### CLI toolkit
+- [zoxide](https://github.com/ajeetdsouza/zoxide) — smart cd that learns your most-used directories
+- [fzf](https://github.com/junegunn/fzf) — fuzzy finder for files, history, and directories
+- [ripgrep](https://github.com/BurntSushi/ripgrep) — fast recursive grep
+- [fd](https://github.com/sharkdp/fd) — fast file finder that respects .gitignore
+- [eza](https://github.com/eza-community/eza) — modern ls with git status and icons
+- [jq](https://github.com/jqlang/jq) / [yq](https://github.com/kislyuk/yq) — JSON and YAML processors
+- [btop](https://github.com/aristocratos/btop) — system monitor
+- [direnv](https://github.com/direnv/direnv) + [nix-direnv](https://github.com/nix-community/nix-direnv) — per-project dev environments via .envrc
+- [devbox](https://github.com/jetify-com/devbox) — portable dev environments for non-Nix contributors
+- [typst](https://github.com/typst/typst) — modern typesetting (LaTeX alternative)
+- [glow](https://github.com/charmbracelet/glow) — terminal markdown renderer
+- [catimg](https://github.com/posva/catimg) — display images in terminal
+- [tree](https://mama.indstate.edu/users/ice/tree/) — directory tree visualization
+- [wget](https://www.gnu.org/software/wget/) — HTTP file downloads
+- [sl](https://github.com/mtoyoda/sl), [cowsay](https://github.com/tnalpgge/rank-amateur-cowsay), [lolcat](https://github.com/busyloop/lolcat), [fortune](https://github.com/shlomif/fortune-mod), [figlet](http://www.figlet.org/), [ponysay](https://github.com/erkin/ponysay)
+
 ## Common tasks 🔧
 
 | Task | Command |

--- a/home/default.nix
+++ b/home/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./shell
     ./git
+    ./tools
   ];
 
   # Let home-manager manage itself (provides the `home-manager` CLI).

--- a/home/shell/default.nix
+++ b/home/shell/default.nix
@@ -6,7 +6,10 @@
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
 
-    initExtra = ''
+    initContent = ''
+      # Case-insensitive tab completion
+      zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+
       # iTerm2 shell integration (command framing, clickable marks, etc.)
       if [ "$TERM_PROGRAM" = "iTerm.app" ]; then
         if [ ! -e "$HOME/.iterm2_shell_integration.zsh" ]; then

--- a/home/tools/default.nix
+++ b/home/tools/default.nix
@@ -1,0 +1,85 @@
+{ pkgs, ... }:
+
+{
+  # zoxide: smart cd that learns your most-used directories
+  programs.zoxide = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+
+  # fzf: fuzzy finder (Ctrl+T files, Ctrl+R history, Alt+C directories)
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+    defaultCommand = "fd --type f --hidden --follow --exclude .git";
+    defaultOptions = [ "--height 40%" "--border" ];
+    fileWidgetCommand = "fd --type f --hidden --follow --exclude .git";
+    changeDirWidgetCommand = "fd --type d --hidden --follow --exclude .git";
+  };
+
+  # direnv: per-project environments via .envrc
+  programs.direnv = {
+    enable = true;
+    enableZshIntegration = true;
+    nix-direnv.enable = true;
+    silent = true;
+  };
+
+  # eza: modern ls with git status and icons
+  programs.eza = {
+    enable = true;
+    enableZshIntegration = true;
+    git = true;
+    icons = "auto";
+  };
+
+  # ripgrep: fast recursive grep
+  programs.ripgrep = {
+    enable = true;
+    arguments = [ "--smart-case" ];
+  };
+
+  # fd: fast file finder (respects .gitignore)
+  programs.fd = {
+    enable = true;
+    hidden = true;
+    ignores = [ ".git/" ];
+  };
+
+  # jq: JSON processor
+  programs.jq.enable = true;
+
+  # tealdeer: fast tldr client (community-maintained command cheatsheets)
+  programs.tealdeer = {
+    enable = true;
+    settings.updates.auto_update = true;
+  };
+
+  # btop: system monitor
+  programs.btop = {
+    enable = true;
+    settings = {
+      color_theme = "Default";
+      theme_background = false;
+    };
+  };
+
+  home.packages = with pkgs; [
+    # CLI toolkit
+    yq          # YAML processor (jq for YAML)
+    wget        # HTTP file downloads
+    tree        # directory tree visualization
+    devbox      # portable dev environments for non-Nix contributors
+    typst       # modern typesetting (LaTeX alternative)
+    catimg      # display images in terminal
+    glow        # terminal markdown renderer
+
+    # essentials
+    sl
+    cowsay
+    lolcat
+    fortune
+    figlet
+    ponysay
+  ];
+}


### PR DESCRIPTION
## Summary

- Add `home/tools` module with the full CLI toolkit: zoxide, fzf (fd-backed), ripgrep, fd, eza, jq, btop, tealdeer, direnv + nix-direnv, yq, wget, tree, devbox, typst, catimg, glow, and essentials (sl, cowsay, lolcat, fortune, figlet, ponysay)
- Add case-insensitive tab completion
- Fix deprecated `initExtra` → `initContent` in shell module
- Add "What's included" section to README documenting all shell, git, and CLI tools

Closes #6

## Test plan

- [x] `make check` passes
- [x] `make switch` succeeds
- [ ] Verify all programs.* tools: `zoxide`, `fzf`, `rg`, `fd`, `eza`, `jq`, `btop`, `tldr`, `direnv`
- [ ] Verify all home.packages tools: `yq`, `wget`, `tree`, `devbox`, `typst`, `catimg`, `glow`
- [ ] Verify essentials: `sl`, `cowsay`, `lolcat`, `fortune`, `figlet`, `ponysay`
- [ ] fzf uses fd as backend: `Ctrl+T`, `Ctrl+R`, `Alt+C`
- [ ] direnv activates in a directory with `.envrc`
- [ ] eza shows git status and icons
- [ ] Case-insensitive tab completion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)