### PR TITLE
feat: support optional machine-local config via local.nix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,15 @@ Three issue templates are defined in `.github/ISSUE_TEMPLATE/`. Always use the a
 - Keep modules focused: one concern per directory (shell, git, editor, etc.)
 - **Platform-specific config:** Use dedicated platform modules (`home/darwin/`, `home/linux/`) rather than `isDarwin`/`isLinux` conditionals in shared modules. These are wired into `makeDarwin` in `flake.nix` via `darwinHomeModules`. Small one-off checks with `pkgs.stdenv.isDarwin` are acceptable, but growing platform-specific config should move to the platform module.
 
+## Machine-local config
+
+Optional local config lives at `~/.config/nix-config/local.nix` (outside the repo). It's imported as a home-manager module by all targets (base and personal) when present and `--impure` is used. Without `--impure`, it's silently skipped.
+
+- Apply with: `make switch IMPURE=1`
+- The file is a standard home-manager module (receives `{ pkgs, ... }`)
+- `nix flake check` and CI are unaffected (pure evaluation = local.nix ignored)
+- See `examples/local.nix` for a starter template
+
 ## State versions — never change these
 
 - `system.stateVersion = 5` in `hosts/darwin/default.nix`

--- a/Makefile
+++ b/Makefile
@@ -9,22 +9,25 @@
 
 UNAME := $(shell uname -s)
 
+# Pass IMPURE=1 to enable --impure (needed for ~/.config/nix-config/local.nix)
+IMPURE_FLAG := $(if $(IMPURE),--impure,)
+
 .PHONY: switch switch-base check update fmt lint clean
 
 ifeq ($(UNAME),Darwin)
 # macOS: rebuild system + home config via nix-darwin
 switch:
-	sudo darwin-rebuild switch --flake .#darwin
+	sudo darwin-rebuild switch --flake .#darwin $(IMPURE_FLAG)
 
 switch-base:
-	sudo darwin-rebuild switch --flake .#darwin-base
+	sudo darwin-rebuild switch --flake .#darwin-base $(IMPURE_FLAG)
 else
 # Linux: rebuild home config via standalone home-manager
 switch:
-	home-manager switch --flake .#linux
+	home-manager switch --flake .#linux $(IMPURE_FLAG)
 
 switch-base:
-	home-manager switch --flake .#linux-base
+	home-manager switch --flake .#linux-base $(IMPURE_FLAG)
 endif
 
 # Validate the flake without applying

--- a/examples/local.nix
+++ b/examples/local.nix
@@ -1,0 +1,19 @@
+# examples/local.nix — template for machine-local config
+#
+# Copy to ~/.config/nix-config/local.nix and customize.
+# Apply with: make switch IMPURE=1
+#
+# This is a standard home-manager module. You can use any option:
+# - home.packages for extra packages
+# - programs.* for program configuration
+# - home.file for dotfile management
+# - home.sessionVariables for environment variables
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    # dotnet-sdk_8
+    # azure-cli
+    # terraform
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,15 @@
     let
       username = "thomas";
 
+      # Optional machine-local home-manager config (outside the repo).
+      # Requires --impure to take effect; silently skipped in pure evaluation.
+      localModules =
+        homeDir:
+        let
+          path = /. + "${homeDir}/.config/nix-config/local.nix";
+        in
+        if builtins.pathExists path then [ path ] else [ ];
+
       # Helper: create a nix-darwin system with the given modules.
       # homeModules: home-manager modules (cross-platform user config)
       # darwinModules: extra nix-darwin system modules (e.g. hosts/darwin/personal.nix)
@@ -58,7 +67,11 @@
               home-manager.useUserPackages = true;
               home-manager.backupFileExtension = "hm-backup";
               home-manager.users.${username} = {
-                imports = homeModules ++ darwinHomeModules ++ [ nixvim.homeModules.nixvim ];
+                imports =
+                  homeModules
+                  ++ darwinHomeModules
+                  ++ [ nixvim.homeModules.nixvim ]
+                  ++ localModules "/Users/${username}";
                 home.username = username;
                 home.homeDirectory = "/Users/${username}";
               };
@@ -80,13 +93,16 @@
                 "claude-code-bin"
               ];
           };
-          modules = homeModules ++ [
-            nixvim.homeModules.nixvim
-            {
-              home.username = username;
-              home.homeDirectory = "/home/${username}";
-            }
-          ];
+          modules =
+            homeModules
+            ++ localModules "/home/${username}"
+            ++ [
+              nixvim.homeModules.nixvim
+              {
+                home.username = username;
+                home.homeDirectory = "/home/${username}";
+              }
+            ];
         };
 
       # Module sets


### PR DESCRIPTION
## Summary

- Add support for `~/.config/nix-config/local.nix` — an optional, untracked home-manager module for machine-specific packages (work SDKs, vendor CLIs, experimental tools)
- Uses `builtins.pathExists` with an absolute path: silently skipped in pure evaluation (default), picked up with `--impure`
- Add `IMPURE=1` flag to Makefile for opt-in impure builds
- Ship `examples/local.nix` as a starter template

## Test plan

- [x] `make check` passes (pure mode, local.nix absent)
- [x] `nix flake check --all-systems` passes
- [x] `make fmt` and `make lint` clean
- [x] `make switch` works without `IMPURE=1` (local.nix silently ignored)
- [x] `make switch IMPURE=1` with a local.nix picks up the extra packages
- [x] CI passes on both platforms

## Related issues

Closes #26
Related: #29 (uses same `~/.config/nix-config/` directory for personal identity fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)