### PR TITLE
ci: adopt shared Renovate config from tskovlund/.github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>tskovlund/.github"]
+}


### PR DESCRIPTION
Adopts the shared Renovate preset (`github>tskovlund/.github`) and retires this repo's Dependabot config. The preset brings: weekly Monday runs, Conventional-Commit messages, auto-merge for non-major updates, grouped + SHA-pinned GitHub Actions, and **nix flake.lock maintenance** (automerged when checks pass).

Depends on tskovlund/.github#29 being merged first — the preset must exist on that repo's `main` to resolve. Renovate's own onboarding PR here (if any) closes itself once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015poiKu38K88t2iBCX9AFpc

---
_Generated by [Claude Code](https://claude.ai/code/session_015poiKu38K88t2iBCX9AFpc)_