### PR TITLE
fix(flake): accept attrset-shaped personal.homeModules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,14 @@
     }:
     let
       inherit (personal) identity;
-      personalHomeModules = personal.homeModules or [ ];
+      # personal.homeModules is an attrset with a `default` aggregate (the
+      # shape flake-schemas requires); tolerate the legacy list shape and
+      # the empty stub so either side can update first.
+      personalHomeModules =
+        let
+          raw = personal.homeModules or [ ];
+        in
+        if builtins.isAttrs raw then [ raw.default ] else raw;
       inherit (identity) username;
 
       # Optional machine-local home-manager config (outside the repo).


### PR DESCRIPTION
First half of the `homeModules` shape fix (consumer side, **merge this before** tskovlund/nix-config-personal's PR).

`nix flake check` on nix-config-personal fails since Determinate Nix started enforcing flake-schemas: `homeModules` must be an attrset of modules, not a list of paths. The personal repo is moving to named modules + a `default` aggregate. This shim accepts both shapes (attrset → `[ raw.default ]`, legacy list and the empty stub → as-is), so either repo can update first — important because miles' auto-upgrade overrides the `personal` input to latest main, bypassing the lockfile.

No behavior change with the current lock: same modules, same (alphabetical) order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015poiKu38K88t2iBCX9AFpc

---
_Generated by [Claude Code](https://claude.ai/code/session_015poiKu38K88t2iBCX9AFpc)_